### PR TITLE
Fix object_id warning

### DIFF
--- a/lib/common_thread/xml/xml_magic.rb
+++ b/lib/common_thread/xml/xml_magic.rb
@@ -2,7 +2,7 @@ module CommonThread
   module XML
     # Credit to Jim Weirich at http://onestepback.org/index.cgi/Tech/Ruby/BlankSlate.rdoc
     class BlankSlate
-      instance_methods.each { |m| undef_method m unless m =~ /^__/ }
+      instance_methods.each { |m| undef_method m unless m =~ /^__/ or m == :object_id }
     end    
     
     # Class that makes accessing xml objects more like any other ruby object


### PR DESCRIPTION
Whenever xml-magic is `require`d, this warning is shown:

```
../gems/xml-magic-0.1.1/lib/common_thread/xml/xml_magic.rb:5: warning: undefining `object_id' may cause serious problems
```

This patch does not undefine the `object_id` method.